### PR TITLE
Update UserContext to fix the bug 

### DIFF
--- a/client/src/context/UserContext.jsx
+++ b/client/src/context/UserContext.jsx
@@ -22,6 +22,9 @@ export function UserContextProvider({ children }) {
         // setReady to true
         setReady(true);
       });
+    } else {
+      // setReady to true
+      setReady(true);
     }
   }, [user]);
   // Return the UserContext provider that wraps the child components


### PR DESCRIPTION
This pull request makes a small update to `client/src/context/UserContext.jsx`, ensuring the `setReady` function sets the state to `true` in both branches of the conditional statement. This fix resolves the bug where, after logging in, clicking the user icon displays a loading page instead of the account page.

* [`client/src/context/UserContext.jsx`](diffhunk://#diff-bf3147f37d7c21478336d9e25849b040e36f985898d01dafc06d1f3486b6c32dR25-R27): Added a call to `setReady(true)` in the `else` branch to ensure the state is set to true.
